### PR TITLE
Frontpage content toggle

### DIFF
--- a/lang/en/theme_essential.php
+++ b/lang/en/theme_essential.php
@@ -234,16 +234,16 @@ $string['enablealternativethemecolorsdesc'] = 'If enabled, the user will be able
 /* Frontpage Settings */
 $string['frontcontentheading'] = 'Front page settings';
 $string['frontcontentheadingsub'] = 'Change what features you wish enabled on your Moodle front page';
-$string['frontcontentdesc'] = 'This adds a custom content area in between the slide show and the Marketing boxes for your own custom content';
+$string['frontcontentdesc'] = 'This adds a custom content area in between the slide show and the Marketing boxes for your own custom content.';
 
-$string['usefrontcontent'] = 'Enable front page content';
-$string['usefrontcontentdesc'] = 'If enabled this will display the content of the box below in between the slide show and the Marketing spots.';
+$string['togglefrontcontent'] = 'Toggle front page content';
+$string['togglefrontcontentdesc'] = 'If enabled this will display the content of the box below in between the slide show and the Marketing spots.';
 
 $string['frontcontentarea'] = 'Front page content';
-$string['frontcontentareadesc'] = 'Whatever is typed into this box will display across the full width of the page in between the slide show and the Marketing spots ';
+$string['frontcontentareadesc'] = 'Whatever is typed into this box will display across the full width of the page in between the slide show and the Marketing spots. ';
 
 $string['frontpagemiddleblocks'] = 'Enable front page middle blocks';
-$string['frontpagemiddleblocksdesc'] = 'If enabled this will display 3 new block locations just under the marketing spots';
+$string['frontpagemiddleblocksdesc'] = 'If enabled this will display three new block locations just under the marketing spots. This will allow you to move moodle blocks into these new locations on the frontpage. If you intend to use the "show before login" option, note that since this hides the blocks on the frontpage, you will need to add content to these blocks first using the "Always show" setting and then change it once your content is established.';
 
 /* Slideshow */
 $string['slideshowheading'] = 'Front page slide show';

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -55,9 +55,8 @@ echo $OUTPUT->doctype() ?>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 
-<?php require_once(dirname(__FILE__).'/includes/header.php');?>
-
 <div id="page" class="container-fluid">
+    <?php require_once(dirname(__FILE__).'/includes/header.php');?>
     <section class="slideshow">
         <!-- Start Slideshow -->
         <?php 
@@ -133,8 +132,14 @@ echo $OUTPUT->doctype() ?>
         <!-- End Alerts -->
 
         <!-- Start Frontpage Content -->
-        <?php if($PAGE->theme->settings->usefrontcontent ==1) { 
-            echo $PAGE->theme->settings->frontcontentarea;
+        <?php 
+            if($PAGE->theme->settings->togglefrontcontent==1) {
+                echo $PAGE->theme->settings->frontcontentarea;
+            } else if($PAGE->theme->settings->togglefrontcontent==2 && !isloggedin()) {
+                echo $PAGE->theme->settings->frontcontentarea;
+            } else if($PAGE->theme->settings->togglefrontcontent==3 && isloggedin()) {
+                echo $PAGE->theme->settings->frontcontentarea;
+            }
         ?>
         <div class="bor" style="margin-top: 10px;"></div>   
         <?php }?>

--- a/settings.php
+++ b/settings.php
@@ -610,16 +610,23 @@ defined('MOODLE_INTERNAL') || die;
     }
     $ADMIN->add('theme_essential', $temp);
     
+  /*Frontpage Settings*/
     $temp = new admin_settingpage('theme_essential_frontcontent', get_string('frontcontentheading', 'theme_essential'));
     $temp->add(new admin_setting_heading('theme_essential_frontcontent', get_string('frontcontentheadingsub', 'theme_essential'),
             format_text(get_string('frontcontentdesc' , 'theme_essential'), FORMAT_MARKDOWN)));
     
-    // Enable Frontpage Content
-    $name = 'theme_essential/usefrontcontent';
-    $title = get_string('usefrontcontent', 'theme_essential');
-    $description = get_string('usefrontcontentdesc', 'theme_essential');
-    $default = false;
-    $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
+  
+    // Toggle Frontpage Content.
+    $name = 'theme_essential/togglefrontcontent';
+    $title = get_string('togglefrontcontent', 'theme_essential');
+    $description = get_string('togglefrontcontentdesc', 'theme_essential');
+    $alwaysdisplay = get_string('alwaysdisplay', 'theme_essential');
+    $displaybeforelogin = get_string('displaybeforelogin', 'theme_essential');
+    $displayafterlogin = get_string('displayafterlogin', 'theme_essential');
+    $dontdisplay = get_string('dontdisplay', 'theme_essential');
+    $default = '1';
+    $choices = array('1'=>$alwaysdisplay, '2'=>$displaybeforelogin, '3'=>$displayafterlogin, '0'=>$dontdisplay);
+    $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
     
@@ -632,19 +639,7 @@ defined('MOODLE_INTERNAL') || die;
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
     
-    // Frontpage Block alignment.
-    $name = 'theme_essential/frontpageblocks';
-    $title = get_string('frontpageblocks' , 'theme_essential');
-    $description = get_string('frontpageblocksdesc', 'theme_essential');
-    $left = get_string('left', 'theme_essential');
-    $right = get_string('right', 'theme_essential');
-    $default = 'left';
-    $choices = array('1'=>$left, '0'=>$right);
-    $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
-    $setting->set_updatedcallback('theme_reset_all_caches');
-    $temp->add($setting);
-    
-    // Toggle Frontpage Middle Blocks
+// Toggle Frontpage Middle Blocks
     $name = 'theme_essential/frontpagemiddleblocks';
     $title = get_string('frontpagemiddleblocks' , 'theme_essential');
     $description = get_string('frontpagemiddleblocksdesc', 'theme_essential');
@@ -659,6 +654,17 @@ defined('MOODLE_INTERNAL') || die;
     $temp->add($setting);
         
     $ADMIN->add('theme_essential', $temp);
+    // Frontpage Block alignment.
+    $name = 'theme_essential/frontpageblocks';
+    $title = get_string('frontpageblocks' , 'theme_essential');
+    $description = get_string('frontpageblocksdesc', 'theme_essential');
+    $left = get_string('left', 'theme_essential');
+    $right = get_string('right', 'theme_essential');
+    $default = 'left';
+    $choices = array('1'=>$left, '0'=>$right);
+    $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $temp->add($setting);
     
 
     /* Marketing Spot Settings */


### PR DESCRIPTION
Changed the enable frontpage content to a toggle similar to the slider
and marketing blocks. #108

Reordered the settings of front page middle blocks so that the toggle
option precedes the positioning settings.  This matches the convention
used elsewhere. #109

Clarified description of the frontpage middle blocks. #110
