### PR TITLE
Google Fonts through https FIX.

### DIFF
--- a/layout/includes/fonts.php
+++ b/layout/includes/fonts.php
@@ -25,5 +25,5 @@
  */
 
 if ($fontselect === '2') { ?>
-    <link href='http://fonts.googleapis.com/css?family=<?php echo $headingfont.'|'.$bodyfont.$fontcharacterset;?>' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=<?php echo $headingfont.'|'.$bodyfont.$fontcharacterset;?>' rel='stylesheet' type='text/css'>
 <?php } ?>


### PR DESCRIPTION
'Http:' prefix in url cause Google Fonts fault when whole moodle site is accessed through https. This modification resolves it - now it works both through http or https.
