### PR TITLE
Add setting to customise header background image.

### DIFF
--- a/lang/en/theme_essential.php
+++ b/lang/en/theme_essential.php
@@ -278,6 +278,8 @@ $string['footerhovercolordesc'] = 'Set the colour for your linked text when hove
 $string['footerheadingcolor'] = 'Footer heading colour';
 $string['footerheadingcolordesc'] = 'Set the colour for block headings in the footer.';
 
+$string['headerbackground'] = 'Header background image';
+$string['headerbackgrounddesc'] = 'Upload your own background image.';
 $string['pagebackground'] = 'Page background image';
 $string['pagebackgrounddesc'] = 'Upload your own background image. Select the style of the image below.';
 $string['pagebackgroundstyle'] = 'Page background style';

--- a/less/essential/settings/theme-admin.less
+++ b/less/essential/settings/theme-admin.less
@@ -66,7 +66,7 @@ img.profilepicture {
 /* @group Header */
 
 #page-header {
-  background: url(~"[[pix:theme|bg/header]]") repeat;
+  background: url(~"'[[setting:headerbackground]]'") repeat;
 }
 
 a.logo {

--- a/lib.php
+++ b/lib.php
@@ -151,6 +151,8 @@ function theme_essential_pluginfile($course, $cm, $context, $filearea, $args, $f
             return $theme->setting_file_serve('logo', $args, $forcedownload, $options);
         } else if ($filearea === 'style') {
             theme_essential_serve_css($args[1]);
+        } else if ($filearea === 'headerbackground') {
+            return $theme->setting_file_serve('headerbackground', $args, $forcedownload, $options);
         } else if ($filearea === 'pagebackground') {
             return $theme->setting_file_serve('pagebackground', $args, $forcedownload, $options);
         } else if (preg_match("/slide[1-9][0-9]*image/", $filearea) !== false) {
@@ -533,6 +535,10 @@ function theme_essential_process_css($css, $theme) {
     $logo = $theme->setting_file_url('logo', 'logo');
     $css = theme_essential_set_logo($css, $logo);
 
+    // Set the background image for the header.
+    $headerbackground = $theme->setting_file_url('headerbackground', 'headerbackground');
+    $css = theme_essential_set_headerbackground($css, $headerbackground);
+
     // Set the background image for the page.
     $pagebackground = $theme->setting_file_url('pagebackground', 'pagebackground');
     $css = theme_essential_set_pagebackground($css, $pagebackground);
@@ -683,6 +689,18 @@ function theme_essential_set_alternativecolor($css, $type, $customcolor, $defaul
         $replacement = $defaultcolor;
     } else {
         $replacement = $customcolor;
+    }
+    $css = str_replace($tag, $replacement, $css);
+    return $css;
+}
+
+function theme_essential_set_headerbackground($css, $headerbackground) {
+    global $OUTPUT;
+    $tag = '[[setting:headerbackground]]';
+    if ($headerbackground) {
+        $replacement = $headerbackground;
+    } else {
+        $replacement = $OUTPUT->pix_url('bg/header', 'theme');
     }
     $css = str_replace($tag, $replacement, $css);
     return $css;

--- a/settings.php
+++ b/settings.php
@@ -46,7 +46,7 @@ if (is_siteadmin()) {
     $temp->add(new admin_setting_heading('theme_essential_generalheading', get_string('generalheadingsub', 'theme_essential'),
         format_text(get_string('generalheadingdesc', 'theme_essential'), FORMAT_MARKDOWN)));
 
-    // Background Image.
+    // Page Background Image.
     $name = 'theme_essential/pagebackground';
     $title = get_string('pagebackground', 'theme_essential');
     $description = get_string('pagebackgrounddesc', 'theme_essential');
@@ -54,7 +54,7 @@ if (is_siteadmin()) {
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
 
-    // Background Image.
+    // Background Style.
     $name = 'theme_essential/pagebackgroundstyle';
     $title = get_string('pagebackgroundstyle', 'theme_essential');
     $description = get_string('pagebackgroundstyledesc', 'theme_essential');
@@ -392,6 +392,14 @@ if (is_siteadmin()) {
         2 => get_string('shortname', 'theme_essential'),
     );
     $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $temp->add($setting);
+
+    // Header Background Image.
+    $name = 'theme_essential/headerbackground';
+    $title = get_string('headerbackground', 'theme_essential');
+    $description = get_string('headerbackgrounddesc', 'theme_essential');
+    $setting = new admin_setting_configstoredfile($name, $title, $description, 'headerbackground');
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
 

--- a/style/settings.css
+++ b/style/settings.css
@@ -556,7 +556,7 @@ img.profilepicture {
 /* @end */
 /* @group Header */
 #page-header {
-  background: url([[pix:theme|bg/header]]) repeat;
+  background: url('[[setting:headerbackground]]') repeat;
 }
 a.logo {
   background-image: [[setting:logo]];


### PR DESCRIPTION
This commit adds a file picker in the Header section of the theme settings which allows administrators to upload an alternative image to use as header background. If no image is specified, the current default (pix/bg/header.png) is used.