### PR TITLE
442 theme_essential: added custom slide size proof-of-concept

### DIFF
--- a/config.php
+++ b/config.php
@@ -37,14 +37,14 @@ $THEME->parents = array();
 $THEME->sheets[] = 'moodle-rtl';
 $THEME->sheets[] = 'bootstrap-pix';
 $THEME->sheets[] = 'moodle-pix';
+$THEME->sheets[] = 'essential';
 $THEME->sheets[] = 'essential-pix';
 $THEME->sheets[] = 'essential-settings';
 $THEME->sheets[] = 'fontawesome';
 
 if ((get_config('theme_essential', 'enablealternativethemecolors1')) ||
     (get_config('theme_essential', 'enablealternativethemecolors2')) ||
-    (get_config('theme_essential', 'enablealternativethemecolors3'))
-) {
+    (get_config('theme_essential', 'enablealternativethemecolors3'))) {
     $THEME->sheets[] = 'essential-alternative';
 }
 

--- a/lang/en/theme_essential.php
+++ b/lang/en/theme_essential.php
@@ -588,3 +588,13 @@ $string['nomessagesfound'] = 'No messages were found';
 $string['blogpreferences'] = 'Blog preferences';
 $string['badgepreferences'] = 'Badge preferences';
 $string['messagepreferences'] = 'Message preferences';
+
+// Slide show size
+$string['slidesize'] = 'Slide show size';
+$string['slidesizedesc'] = 'The height of the slide show. Full corresponds to 368 pixel at full screen, Very small corresonds fo 36 pixel at full screen';
+$string['slide10percent'] = 'Very small';
+$string['slide25percent'] = 'Small';
+$string['slide50percent'] = 'Medium';
+$string['slide75percent'] = 'Big';
+$string['slide100percent'] = 'Full';
+

--- a/lib.php
+++ b/lib.php
@@ -390,6 +390,55 @@ function theme_essential_hex2rgba($hex, $opacity) {
 }
 
 /**
+ * theme_essential_set_slide_size
+ *
+ * @param string $css The original CSS.
+ * @param string $slideheight The slide height in percent.
+ * @return string The modified CSS.
+ */
+function theme_essential_set_slide_size($css, $slidesize) {
+// global $CFG;
+
+    if ($slidesize > 100) {
+        $slidesize = 100;
+    }
+
+    $slidesize /= 100;
+
+    $cases = range(1, 4);
+    foreach ($cases as $case) {
+        $tagbase = '[[setting:slidesize_case'."$case";
+        switch ($case) {
+            case 1:
+                $slideheight = $slidesize * 200;
+                break;
+            case 2:
+                $slideheight = $slidesize * 260;
+                break;
+            case 3:
+                $slideheight = $slidesize * 328;
+                break;
+            case 4:
+                $slideheight = $slidesize * 368;
+                break;
+        }
+        $tag = $tagbase.']]';
+        $replacement = intval($slideheight);
+        $css = str_replace($tag, $replacement . 'px', $css);
+
+        $tag = $tagbase.'_90percent]]';
+        $replacement = intval($slideheight * 0.9);
+        $css = str_replace($tag, $replacement . 'px', $css);
+
+        $tag = $tagbase.'_135percent]]';
+        $replacement = intval($slideheight * 1.35);
+        $css = str_replace($tag, $replacement . 'px', $css);
+    }
+
+    return $css;
+}
+
+/**
  * Adds any custom CSS to the CSS before it is cached.
  *
  * @param string $css The original CSS.
@@ -416,6 +465,10 @@ function theme_essential_process_css($css, $theme) {
     $css = theme_essential_set_bodyfont($css, $bodyfont);
     $css = theme_essential_set_fontfiles($css, 'heading', $headingfont);
     $css = theme_essential_set_fontfiles($css, 'body', $bodyfont);
+
+    // Set the slide size.
+    $slidesize = theme_essential_get_setting('slidesize');
+    $css = theme_essential_set_slide_size($css, $slidesize);
 
     // Set the theme colour.
     $themecolor = theme_essential_get_setting('themecolor');

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -1309,7 +1309,7 @@ class theme_essential_core_renderer extends core_renderer {
         if ($captionoptions == 0) {
             $slide .= '<div class="container-fluid">';
             $slide .= '<div class="row-fluid">';
-        
+
             if ($slidetitle || $slidecaption) {
                 $slide .= '<div class="span5 the-side-caption">';
                 $slide .= '<div class="the-side-caption-content">';

--- a/settings.php
+++ b/settings.php
@@ -1376,6 +1376,22 @@ if (is_siteadmin()) {
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
 
+    // Slide size.
+    $name = 'theme_essential/slidesize';
+    $title = get_string('slidesize', 'theme_essential');
+    $description = get_string('slidesizedesc', 'theme_essential');
+    $default = '100';
+    $choices = array(
+         10 => get_string('slide10percent', 'theme_essential'),
+         25 => get_string('slide25percent', 'theme_essential'),
+         50 => get_string('slide50percent', 'theme_essential'),
+         75 => get_string('slide75percent', 'theme_essential'),
+        100 => get_string('slide100percent', 'theme_essential'),
+    );
+    $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $temp->add($setting);
+
     // Slide Text colour setting.
     $name = 'theme_essential/slidecolor';
     $title = get_string('slidecolor', 'theme_essential');

--- a/style/essential-rtl.css
+++ b/style/essential-rtl.css
@@ -20644,15 +20644,15 @@ table.calendarmonth.calendartable {
 
 @media (max-width: 767px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 200px;
+    height: [[setting:slidesize_case1]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 200px;
+    line-height: [[setting:slidesize_case1]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 165px;
+    max-height: [[setting:slidesize_case1_90percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-caption {
@@ -20673,7 +20673,7 @@ table.calendarmonth.calendartable {
 
   #essentialCarousel.carousel .carousel-inner.below > .item,
   #essentialCarousel.carousel .carousel-inner > .item.side-caption {
-    height: 280px;
+    height: [[setting:slidesize_case1_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-caption,
@@ -20683,25 +20683,25 @@ table.calendarmonth.calendartable {
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption,
   #essentialCarousel.carousel .carousel-inner > .item.side-caption .carousel-image-container.nocaption {
-    line-height: 280px;
+    line-height: [[setting:slidesize_case1_135percent]];
   }
 }
 
 @media (min-width: 768px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 260px;
+    height: [[setting:slidesize_case2]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 260px;
+    line-height: [[setting:slidesize_case2]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 225px;
+    max-height: [[setting:slidesize_case2_90percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption {
-    height: 260px;
+    height: [[setting:slidesize_case2]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption:before {
@@ -20728,7 +20728,7 @@ table.calendarmonth.calendartable {
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item {
-    height: 345px;
+    height: [[setting:slidesize_case2_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-caption {
@@ -20736,7 +20736,7 @@ table.calendarmonth.calendartable {
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption {
-    line-height: 345px;
+    line-height: [[setting:slidesize_case2_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-control {
@@ -20752,19 +20752,19 @@ table.calendarmonth.calendartable {
 
 @media (min-width: 992px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 328px;
+    height: [[setting:slidesize_case3]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 328px;
+    line-height: [[setting:slidesize_case3]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 293px;
+    max-height: [[setting:slidesize_case3_90percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption {
-    height: 328px;
+    height: [[setting:slidesize_case3]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption h4 {
@@ -20776,7 +20776,7 @@ table.calendarmonth.calendartable {
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item {
-    height: 428px;
+    height: [[setting:slidesize_case4_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-caption {
@@ -20784,7 +20784,7 @@ table.calendarmonth.calendartable {
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption {
-    line-height: 428px;
+    line-height: [[setting:slidesize_case3_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-control {
@@ -20794,19 +20794,19 @@ table.calendarmonth.calendartable {
 
 @media (min-width: 1200px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 368px;
+    height: [[setting:slidesize_case4]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 368px;
+    line-height: [[setting:slidesize_case4]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 333px;
+    max-height: [[setting:slidesize_case4_90percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption {
-    height: 368px;
+    height: [[setting:slidesize_case4]];
   }
 
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption h4 {
@@ -20818,11 +20818,11 @@ table.calendarmonth.calendartable {
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item {
-    height: 468px;
+    height: [[setting:slidesize_case4_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption {
-    line-height: 468px;
+    line-height: [[setting:slidesize_case4_135percent]];
   }
 
   #essentialCarousel.carousel .carousel-control {
@@ -23435,7 +23435,7 @@ body.format-topcoll .course-content ul.ctopics li.section.main {
 
 @media (max-width: 979px) {
   font-size: 13px !important;
-  
+
   h1#title {
     font-size: 2.5em;
     line-height: 35px;

--- a/style/essential.css
+++ b/style/essential.css
@@ -17183,13 +17183,13 @@ table.calendarmonth.calendartable {
 }
 @media (max-width: 767px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 200px;
+    height: [[setting:slidesize_case1]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 200px;
+    line-height: [[setting:slidesize_case1]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 165px;
+    max-height: [[setting:slidesize_case1_90percent]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-caption {
     position: absolute;
@@ -17205,7 +17205,7 @@ table.calendarmonth.calendartable {
   }
   #essentialCarousel.carousel .carousel-inner.below > .item,
   #essentialCarousel.carousel .carousel-inner > .item.side-caption {
-    height: 280px;
+    height: [[setting:slidesize_case1_135percent]];
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-caption,
   #essentialCarousel.carousel .carousel-inner > .item.side-caption .carousel-caption {
@@ -17213,21 +17213,21 @@ table.calendarmonth.calendartable {
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption,
   #essentialCarousel.carousel .carousel-inner > .item.side-caption .carousel-image-container.nocaption {
-    line-height: 280px;
+    line-height: [[setting:slidesize_case1_135percent]];
   }
 }
 @media (min-width: 768px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 260px;
+    height: [[setting:slidesize_case2]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 260px;
+    line-height: [[setting:slidesize_case2]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 225px;
+    max-height: [[setting:slidesize_case2_90percent]];
   }
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption {
-    height: 260px;
+    height: [[setting:slidesize_case2]];
   }
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption:before {
     content: '';
@@ -17249,13 +17249,13 @@ table.calendarmonth.calendartable {
     font-size: 14px;
   }
   #essentialCarousel.carousel .carousel-inner.below > .item {
-    height: 345px;
+    height: [[setting:slidesize_case2_135percent]];
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-caption {
     height: 55px;
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption {
-    line-height: 345px;
+    line-height: [[setting:slidesize_case2_135percent]];
   }
   #essentialCarousel.carousel .carousel-control {
     font-size: 40px;
@@ -17268,16 +17268,16 @@ table.calendarmonth.calendartable {
 }
 @media (min-width: 992px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 328px;
+    height: [[setting:slidesize_case3]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 328px;
+    line-height: [[setting:slidesize_case3]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 293px;
+    max-height: [[setting:slidesize_case3_90percent]];
   }
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption {
-    height: 328px;
+    height: [[setting:slidesize_case3]];
   }
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption h4 {
     font-size: 26px;
@@ -17286,13 +17286,13 @@ table.calendarmonth.calendartable {
     font-size: 18px;
   }
   #essentialCarousel.carousel .carousel-inner.below > .item {
-    height: 428px;
+    height: [[setting:slidesize_case4_135percent]];
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-caption {
     height: 65px;
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption {
-    line-height: 428px;
+    line-height: [[setting:slidesize_case4_135percent]];
   }
   #essentialCarousel.carousel .carousel-control {
     font-size: 50px;
@@ -17300,16 +17300,16 @@ table.calendarmonth.calendartable {
 }
 @media (min-width: 1200px) {
   #essentialCarousel.carousel .carousel-inner > .item {
-    height: 368px;
+    height: [[setting:slidesize_case4]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image-container {
-    line-height: 368px;
+    line-height: [[setting:slidesize_case4]];
   }
   #essentialCarousel.carousel .carousel-inner > .item .carousel-image {
-    max-height: 333px;
+    max-height: [[setting:slidesize_case4_90percent]];
   }
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption {
-    height: 368px;
+    height: [[setting:slidesize_case4]];
   }
   #essentialCarousel.carousel .carousel-inner > .item.side-caption div.the-side-caption h4 {
     font-size: 32px;
@@ -17318,10 +17318,10 @@ table.calendarmonth.calendartable {
     font-size: 20px;
   }
   #essentialCarousel.carousel .carousel-inner.below > .item {
-    height: 468px;
+    height: [[setting:slidesize_case4_135percent]];
   }
   #essentialCarousel.carousel .carousel-inner.below > .item .carousel-image-container.nocaption {
-    line-height: 468px;
+    line-height: [[setting:slidesize_case4_135percent]];
   }
   #essentialCarousel.carousel .carousel-control {
     font-size: 60px;
@@ -19454,7 +19454,7 @@ body.format-topcoll .course-content ul.ctopics li.section.main {
 }
 @media (max-width: 979px) {
   font-size: 13px !important;
-  
+
   h1#title {
     font-size: 2.5em;
     line-height: 35px;


### PR DESCRIPTION
This is my first pull request here in github. I apologise if it is not well done.
For sure I need to submit to your attention what follows:
1) I had to add $THEME->sheets[] = 'essential'; as line 40 of config.php because my tags were not replaced. I wonder if I need to add $THEME->sheets[] = 'essential-rtl'; too. I tried but I get a mess. I am sure I need your supervision for this detail.
2) I did not make any test with rtl languages.
3) As far I can understand, the string $string['slideshowdesc'] is incorrect because it dials about "screen width < 767px = height 165px, width between 768px and 979px = height 225px and width > 980px = height 300px" but I found that the screen width are four.
