### PR TITLE
Fix: Unable to find CSS when themedir set but theme is in default dir

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -177,10 +177,10 @@ function theme_essential_pluginfile($course, $cm, $context, $filearea, $args, $f
 
 function theme_essential_serve_css($filename) {
     global $CFG;
-    if (!empty($CFG->themedir)) {
+
+    $thestylepath = $CFG->dirroot . '/theme/essential/style/';
+    if (!empty($CFG->themedir) && file_exists("{$CFG->themedir}/essential/style/")) {
         $thestylepath = $CFG->themedir . '/essential/style/';
-    } else {
-        $thestylepath = $CFG->dirroot . '/theme/essential/style/';
     }
     $thesheet = $thestylepath . $filename;
 


### PR DESCRIPTION
In Moodle, themes are allowed to be installed in the normal theme directory or the $CFG->themedir directory.  However, the Essential theme is broken (no CSS) in M27 and M28 when it is installed in the default directory and $CFG->themedir is set.  This patch fixes the CSS loading function to look in both the default directory and the themedir directory, rather than only the themedir directory if it exists.