### PR TITLE
RE: Footer doesn't stay at bottom #351

### DIFF
--- a/layout/admin.php
+++ b/layout/admin.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 
 $footerregion = essential_has_footer_region(); // In pagesettings.php.
@@ -81,6 +83,6 @@ $footerregion = essential_has_footer_region(); // In pagesettings.php.
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
-
+</div>
 </body>
 </html>

--- a/layout/columns1.php
+++ b/layout/columns1.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 ?>
 
@@ -55,5 +57,6 @@ require_once($OUTPUT->get_include_file('header'));
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
+</div>
 </body>
 </html>

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 
 $footerregion = essential_has_footer_region(); // In pagesettings.php.
@@ -80,5 +82,6 @@ $footerregion = essential_has_footer_region(); // In pagesettings.php.
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
+</div>
 </body>
 </html>

--- a/layout/columns3.php
+++ b/layout/columns3.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 ?>
 
@@ -68,5 +70,6 @@ require_once($OUTPUT->get_include_file('header'));
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
+</div>
 </body>
 </html>

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 
 $enable1alert = $OUTPUT->get_setting('enable1alert');
@@ -185,7 +187,7 @@ if ($enable1alert || $enable2alert || $enable3alert) {
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
-
+</div>
 <!-- Initialize slideshow -->
 <script type="text/javascript">
     jQuery(document).ready(function () {

--- a/layout/login.php
+++ b/layout/login.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 ?>
 
@@ -44,5 +46,6 @@ require_once($OUTPUT->get_include_file('header'));
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
+</div>
 </body>
 </html>

--- a/layout/report.php
+++ b/layout/report.php
@@ -23,7 +23,9 @@
  * @copyright   2014 Gareth J Barnard, David Bezemer
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
+?>
+<div id="pageWrapper">
+<?php
 require_once($OUTPUT->get_include_file('header'));
 ?>
 
@@ -63,5 +65,6 @@ require_once($OUTPUT->get_include_file('header'));
 </div>
 
 <?php require_once($OUTPUT->get_include_file('footer')); ?>
+</div>
 </body>
 </html>


### PR DESCRIPTION
In the layout files, I added a <div id="pageWrapper"> around most of the page (including the footer), and then targeted a few things in css. It's based on: http://cssreset.com/how-to-keep-footer-at-bottom-of-page-with-css/ and only uses css. Of course... you do need to set a height for the footer (I'm happy to do so, but others may not be) and the padding-bottom in the #page needs to be at least the height of the footer.
I placed the CSS below in the custom css area of the theme's general settings page:

html, body {
height:100%;
}

#pageWrapper {
position:relative;
min-height:100%;
}

#page {
padding-bottom: 300px;
}

#page-footer {
position:absolute;
bottom:0;
height:250px;
min-height:200px;
}