### PR TITLE
load parent theme to pass to theme_essential_process_css

### DIFF
--- a/essentials/lib.php
+++ b/essentials/lib.php
@@ -29,7 +29,8 @@ function theme_essentials_process_css($css, $theme) {
 
     if ($usingessentialsettings) {
         require_once(dirname(__FILE__) . '/../essential/lib.php');
-        $css = theme_essential_process_css($css, $theme);
+        $parenttheme = theme_config::load('essential'); 
+        $css = theme_essential_process_css($css, $parenttheme);
     }
 
     // If you have your own settings, then add them here.


### PR DESCRIPTION
Passing the Essentials theme as a parameter to theme_essential_process_css will not allow us to use the Essential settings. We need to pass the Essential theme object.