### PR TITLE
Fix: Unable to find CSS when themedir set but theme is in default the…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -177,10 +177,10 @@ function theme_essential_pluginfile($course, $cm, $context, $filearea, $args, $f
 
 function theme_essential_serve_css($filename) {
     global $CFG;
-    if (!empty($CFG->themedir)) {
+
+    $thestylepath = $CFG->dirroot . '/theme/essential/style/';
+    if (!empty($CFG->themedir) && file_exists("{$CFG->themedir}/essential/style/")) {
         $thestylepath = $CFG->themedir . '/essential/style/';
-    } else {
-        $thestylepath = $CFG->dirroot . '/theme/essential/style/';
     }
     $thesheet = $thestylepath . $filename;
 


### PR DESCRIPTION
Hello,
  This is Logan Reynolds with Remote-Learner.  I've found that the most recent download files at https://moodle.org/plugins/pluginversions.php?plugin=theme_essential work for M28/M29, but the M27 download does not seem to incorporate previous fixes to make the static theme resources serveable out of an alternate directory.  Requesting that this change be accepted into your MOODLE_27 branch, and then this branch replace the current M27-specific version on Moodle.org at the above download url.

Please feel free to contact if you have any questions.

Regards,
Logan Reynolds