### PR TITLE
add setting to toggle display of hidden courses in Custom Menu

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -410,13 +410,14 @@ class core_renderer extends \core_renderer {
 
             // Retrieve courses and add them to the menu when they are visible.
             $numcourses = 0;
+            $hasdisplayhiddenmycourses = \theme_essential\toolbox::get_setting('displayhiddenmycourses');
             if ($courses = enrol_get_my_courses(null, $sortorder . ' ASC')) {
                 foreach ($courses as $course) {
                     if ($course->visible) {
                         $branch->add('<span class="fa fa-graduation-cap"></span>'.format_string($course->fullname),
                             new moodle_url('/course/view.php?id=' . $course->id), format_string($course->shortname));
                         $numcourses += 1;
-                    } else if (has_capability('moodle/course:viewhiddencourses', context_course::instance($course->id))) {
+                    } else if (has_capability('moodle/course:viewhiddencourses', context_course::instance($course->id)) && $hasdisplayhiddenmycourses) {
                         $branchtitle = format_string($course->shortname);
                         $branchlabel = '<span class="dimmed_text">'.$this->getfontawesomemarkup('slash').
                             format_string($course->fullname) . '</span>';

--- a/lang/en/theme_essential.php
+++ b/lang/en/theme_essential.php
@@ -181,6 +181,8 @@ $string['mycoursesinfo'] = 'Enrolled courses menu';
 $string['mycoursesinfodesc'] = 'Displays a dynamic list of enrolled courses to the user.';
 $string['displaymycourses'] = 'Display enrolled courses';
 $string['displaymycoursesdesc'] = 'Display enrolled courses for users in the Custom Menu';
+$string['displayhiddenmycourses'] = 'Display hidden courses';
+$string['displayhiddenmycoursesdesc'] = 'Display hidden courses for users in the Custom Menu if they have permission to view hidden courses';
 
 $string['mycoursetitle'] = 'Terminology';
 $string['mycoursetitledesc'] = 'Change the terminology for the "My Courses" link in the drop down menu';

--- a/settings.php
+++ b/settings.php
@@ -766,7 +766,7 @@ if ($ADMIN->fulltree) {
     $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
     $setting->set_updatedcallback('theme_reset_all_caches');
     $essentialsettingsheader->add($setting);
-    
+
     // Toggle hidden courses display in custommenu.
     $name = 'theme_essential/displayhiddenmycourses';
     $title = get_string('displayhiddenmycourses', 'theme_essential');
@@ -775,7 +775,7 @@ if ($ADMIN->fulltree) {
     $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
     $setting->set_updatedcallback('theme_reset_all_caches');
     $temp->add($setting);
-    
+
     // Set terminology for dropdown course list.
     $name = 'theme_essential/mycoursetitle';
     $title = get_string('mycoursetitle', 'theme_essential');

--- a/settings.php
+++ b/settings.php
@@ -766,7 +766,16 @@ if ($ADMIN->fulltree) {
     $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
     $setting->set_updatedcallback('theme_reset_all_caches');
     $essentialsettingsheader->add($setting);
-
+    
+    // Toggle hidden courses display in custommenu.
+    $name = 'theme_essential/displayhiddenmycourses';
+    $title = get_string('displayhiddenmycourses', 'theme_essential');
+    $description = get_string('displayhiddenmycoursesdesc', 'theme_essential');
+    $default = true;
+    $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    $temp->add($setting);
+    
     // Set terminology for dropdown course list.
     $name = 'theme_essential/mycoursetitle';
     $title = get_string('mycoursetitle', 'theme_essential');


### PR DESCRIPTION
This small change permits users to toggle the display of hidden courses in the 'My Courses' menu.  The use case relates to users who work with both visible (or live) courses as well as hidden (development) courses.  In these cases, those with a dozen or more hidden courses encounter a usability problem when the hidden courses clutter the custom menu.  This change would provide a resolution without the need to make changes to role definitions.