### PR TITLE
Accessibility: politely Inform the the screen reader on slide change

### DIFF
--- a/layout/tiles/slideshow.php
+++ b/layout/tiles/slideshow.php
@@ -57,7 +57,7 @@ if ($numberofslides) {
     ?>
     <div class="row-fluid">
         <div class="span12">
-            <div id="essentialCarousel" class="carousel slide" data-interval="<?php echo $slideinterval;?>">
+            <div id="essentialCarousel" class="carousel slide" aria-live="polite" data-interval="<?php echo $slideinterval;?>">
                 <?php echo $OUTPUT->essential_edit_button('theme_essential_slideshow');?>
                 <ol class="carousel-indicators">
                     <?php echo \theme_essential\toolbox::render_indicators($numberofslides); ?>


### PR DESCRIPTION
Hi Gareth,
I am getting an accessibility audit to our system and to the Essential theme.
So here is one tiny and important fix.
Which instructs the screen reader to wait until it finishes reading the current slide's content before starting to read the new slide that already switched. which, btw, I am told... is confusing to the listener and so we made the interval bigger and tried to shorten the text we put inside the sliders.

Also, as an alternative, our accessibility advisor asked us to disable the auto switching of slides. 

Maybe we should put some good advise in the theme settings help? as I have no idea how system administrator with no experience using a screen reader can know about these anomalies.