### PR TITLE
Accessibility: missing aria-label attribute in "back-to-top" element

### DIFF
--- a/layout/tiles/footer.php
+++ b/layout/tiles/footer.php
@@ -57,6 +57,7 @@ if (empty($PAGE->layout_options['nofooter'])) { ?>
             </div>
         </div>
     </footer>
-    <a href="#top" class="back-to-top" ><span aria-hidden="true" class="fa fa-angle-up "></span></a>
+    <a href="#top" class="back-to-top" aria-label="<?php echo get_string('backtotop', 'theme_essential'); ?>">
+        <span aria-hidden="true" class="fa fa-angle-up "></span></a>
 <?php }
 echo $OUTPUT->standard_end_of_body_html();


### PR DESCRIPTION
Please see if it was added elegant enough, or needed some more love before integrated.
(It definitely solved the accessibility errors I was getting with "Wave" || "Axe" || "Chrome Accessibility addon")