### PR TITLE
Accessibility: missing ALT attribute in course summary images

### DIFF
--- a/classes/core_course_renderer.php
+++ b/classes/core_course_renderer.php
@@ -206,7 +206,7 @@ class theme_essential_core_course_renderer extends core_course_renderer {
                     $file->get_filearea(). $file->get_filepath(). $file->get_filename(), !$isimage);
             if ($isimage) {
                 $contentimages .= html_writer::tag('div',
-                        html_writer::empty_tag('img', array('src' => $url)),
+                        html_writer::empty_tag('img', array('src' => $url, 'alt' => $file->get_filename())),
                         array('class' => 'courseimage'));
             } else {
                 $image = $this->output->pix_icon(file_file_icon($file, 24), $file->get_filename(), 'moodle');


### PR DESCRIPTION
I added the filename as ALT, which seems wrong, but as far as I researched the Moodle code... using Atto for adding an Image, the description is immediately saved as an ALT attribute in the content, but not in the mdl_files DB table. and so, unavailable if we use that image file elsewhere like at the above course summary attached files (and not as links but as images) looks like we need a new accessibility MDL on the tracker. what do you think?