### PR TITLE
Fixed accesibility issue: missing alt attribute in site logo.

### DIFF
--- a/layout/tiles/header.php
+++ b/layout/tiles/header.php
@@ -82,7 +82,7 @@ if (!$haslogo) {
 } else {
     echo '<div class="pull-left logo-container">';
     echo '<a class="logo" href="'.preg_replace("(https?:)", "", $CFG->wwwroot).'" title="'.get_string('home').'">';
-    echo '<img src="'.\theme_essential\toolbox::get_setting('logo', 'format_file_url').'" class="img-responsive" />';
+    echo '<img src="'.\theme_essential\toolbox::get_setting('logo', 'format_file_url').'" class="img-responsive" alt="'.$SITE->shortname. '"/>';
     echo '</a>';
 }
 ?>


### PR DESCRIPTION
Today i realized that img tag for site logo is missing alt attribute. Looking at Boost theme I saw they use site's shortname for alt, so I'm sending you this pull request.
